### PR TITLE
Prevent exception in sanitize limit

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -335,7 +335,7 @@ module ActiveRecord
         if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
           limit
         elsif limit.to_s.include?(',')
-          Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
+          Arel.sql limit.to_s.split(',').map(&:to_i).join(',')
         else
           Integer(limit)
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1012,7 +1012,7 @@ module ActiveRecord
             end
 
           elsif [:datetime, :time].include?(type) && precision ||= native[:precision]
-            if (0..6) === precision
+            if (0..6).cover? precision
               column_type_sql << "(#{precision})"
             else
               raise(ActiveRecordError, "No #{native[:name]} type has precision of #{precision}. The allowed range of precision is from 0 to 6")

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix using `add_source` with a block after using `gem` in a custom generator.
+
+    *Will Fisher*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
 *   No changes.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -75,7 +75,7 @@ module Rails
 
         in_root do
           if block
-            append_file "Gemfile", "source #{quote(source)} do", force: true
+            append_file "Gemfile", "\nsource #{quote(source)} do", force: true
             @in_group = true
             instance_eval(&block)
             @in_group = false

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -52,6 +52,15 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
   end
 
+  def test_add_source_with_block_adds_source_to_gemfile_after_gem
+    run_generator
+    action :gem, 'will-paginate'
+    action :add_source, 'http://gems.github.com' do
+      gem 'rspec-rails'
+    end
+    assert_file 'Gemfile', /gem 'will-paginate'\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
+  end
+
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'


### PR DESCRIPTION
Use `to_i` instead of `Integer()` to save `ArgumentError: invalid value for Integer()` exception
